### PR TITLE
Update getNodeAtPoint to get the closest node

### DIFF
--- a/custom_components/climate_scheduler/frontend/graph.js
+++ b/custom_components/climate_scheduler/frontend/graph.js
@@ -1452,17 +1452,29 @@ class TemperatureGraph {
     }
     
     getNodeAtPoint(point) {
+        // Preconditions
+        if (this.nodes.length == 0) {
+            return null;  // No nodes, so no node at point
+        }
+        if (!point || typeof point.x !== 'number' || typeof point.y !== 'number') {
+            throw new Error('point must be an object with numeric x and y properties')
+        }
+
+        // Logic
+        let closestIndex = null;
+        let closestDistance = Infinity;
         for (let i = 0; i < this.nodes.length; i++) {
             const node = this.nodes[i];
             const x = this.timeToX(node.time);
             const y = this.tempToY(node.temp);
             const distance = Math.sqrt(Math.pow(point.x - x, 2) + Math.pow(point.y - y, 2));
             
-            if (distance <= this.nodeTouchRadius) {
-                return i;
+            if (distance <= this.nodeTouchRadius && distance < closestDistance) {
+                closestDistance = distance;
+                closestIndex = i;
             }
         }
-        return null;
+        return closestIndex;
     }
 
     getSortedNodeIndices() {


### PR DESCRIPTION
When using mobile I noticed that touch would sometimes get the wrong node, and I'd have to touch 'around' the node I actually wanted.

I believe what's happening is that it's finding the first node in the internal storage that is within distance right now, which may not be the closest (or temporally first) node.

This change updates that method to compare the touch point to _all_ nodes and find the closest one